### PR TITLE
refactor: centralize shared game payload serialization

### DIFF
--- a/apps/backend/src/core/serialization.ts
+++ b/apps/backend/src/core/serialization.ts
@@ -62,10 +62,7 @@ function buildBaseGamePayload(game: Game) {
     fragment: game.fragment,
     bombDuration: game.getBombDuration(),
     players: game.players.map((pl) => toGamePlayerView(pl, game.rules)),
-  } satisfies Pick<
-    GameStartedPayload,
-    'fragment' | 'bombDuration' | 'players'
-  >;
+  } satisfies Pick<GameStartedPayload, 'fragment' | 'bombDuration' | 'players'>;
 }
 
 function getCurrentPlayerId(game: Game): string {


### PR DESCRIPTION
## Summary
- extract a shared helper for building the reusable fragment/bomb/player payload
- reuse the helper when serializing turn started and game started events to remove duplication

## Testing
- pnpm --filter backend test

------
https://chatgpt.com/codex/tasks/task_e_68d86f344468832eab91f36a23d5e895