### PR TITLE
Refactor GameEngine timeout handling

### DIFF
--- a/apps/backend/test/gameEngine.test.ts
+++ b/apps/backend/test/gameEngine.test.ts
@@ -164,4 +164,43 @@ describe('GameEngine extra coverage', () => {
     vi.advanceTimersByTime(1100);
     expect(onGameEnded).toHaveBeenCalled();
   });
+
+  it('invokes onTurnTimeout callback when provided', () => {
+    const game = makeGame();
+    game.__setBombDurationForTest(1);
+    const onTurnTimeout = vi.fn();
+    const engine = new GameEngine({
+      game,
+      emit: function emit() {
+        /* noop */
+      },
+      scheduler: {
+        schedule: (delayMs, cb) => setTimeout(cb, delayMs),
+        cancel: (token) => {
+          clearTimeout(token as any);
+        },
+      },
+      eventsPort: {
+        turnStarted: () => {
+          /* noop */
+        },
+        playerUpdated: () => {
+          /* noop */
+        },
+        wordAccepted: () => {
+          /* noop */
+        },
+        gameEnded: () => {
+          /* noop */
+        },
+      },
+      onTurnTimeout,
+    });
+
+    engine.beginGame();
+    vi.advanceTimersByTime(1100);
+
+    expect(onTurnTimeout).toHaveBeenCalledTimes(1);
+    expect(onTurnTimeout.mock.calls[0][0].id).toBe('A');
+  });
 });


### PR DESCRIPTION
## Summary
- extract helper methods in `GameEngine` to centralize timeout handling and event emission
- remove redundant validation wrapper and reuse the new helpers for word acceptance
- add a unit test ensuring the optional `onTurnTimeout` callback is invoked

## Testing
- pnpm format
- pnpm --filter backend lint
- pnpm test
- pnpm --filter backend test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d8796a1680832e968ed3e98af7b716