### PR TITLE
Fix RoomRulesDialog minimum words validation

### DIFF
--- a/apps/frontend/src/components/RoomRulesDialog.tsx
+++ b/apps/frontend/src/components/RoomRulesDialog.tsx
@@ -215,7 +215,6 @@ export function RoomRulesDialog({
                   type="number"
                   min={1}
                   max={1000}
-                  step={25}
                   value={draft.minWordsPerPrompt}
                   onChange={(e) => {
                     setDraft((prev) => ({


### PR DESCRIPTION
## Summary
- remove the minimum words per prompt number input step so the browser accepts any value between 1 and 1000

## Testing
- pnpm format
- pnpm lint --filter frontend *(fails: existing lint issues in unrelated files)*
- pnpm test --filter frontend


------
https://chatgpt.com/codex/tasks/task_e_68dab0322784832ebddcad21f5aa0d88