### PR TITLE
Handle disconnect forfeits and show reconnecting state

### DIFF
--- a/apps/backend/src/core/serialization.test.ts
+++ b/apps/backend/src/core/serialization.test.ts
@@ -83,6 +83,7 @@ describe('serialization player views', () => {
     expect(view.bonusProgress).toBeDefined();
     expect(view.bonusProgress?.remaining.length).toBe(26);
     expect(view.bonusProgress?.total.length).toBe(26);
+    expect(view.isConnected).toBe(false);
   });
 });
 

--- a/apps/backend/src/core/serialization.ts
+++ b/apps/backend/src/core/serialization.ts
@@ -27,6 +27,7 @@ export function toGamePlayerView(
     name: p.name,
     isEliminated: p.isEliminated,
     lives: p.lives,
+    isConnected: p.isConnected,
     bonusProgress: p.getBonusProgressSnapshot(rules.bonusTemplate),
   };
 }

--- a/apps/backend/src/game/GameEngine.ts
+++ b/apps/backend/src/game/GameEngine.ts
@@ -132,4 +132,45 @@ export class GameEngine {
       this.timeoutToken = null;
     }
   }
+
+  public forfeitPlayer(playerId: string): void {
+    const player = this.game.players.find((p) => p.id === playerId);
+    if (!player || player.isEliminated) return;
+
+    let currentId: string | null = null;
+    try {
+      currentId = this.rules.getCurrentPlayer().id;
+    } catch {
+      currentId = null;
+    }
+
+    player.lives = 0;
+    player.eliminate();
+    this.notifyPlayerUpdated(player);
+
+    if (this.handleGameOverIfAny()) {
+      this.clearTimeout();
+      return;
+    }
+
+    if (currentId && currentId === playerId) {
+      const active = this.game.getActivePlayers();
+      if (active.length > 0) {
+        this.game.currentTurnIndex = active.length - 1;
+      }
+      this.advanceTurn();
+      return;
+    }
+
+    if (currentId && currentId !== playerId) {
+      const active = this.game.getActivePlayers();
+      const index = active.findIndex((p) => p.id === currentId);
+      if (index >= 0) {
+        this.game.currentTurnIndex = index;
+        return;
+      }
+    }
+
+    this.advanceTurn();
+  }
 }

--- a/apps/backend/src/socket/roomHandlers.ts
+++ b/apps/backend/src/socket/roomHandlers.ts
@@ -821,9 +821,13 @@ export function registerRoomHandlers(io: TypedServer, socket: TypedSocket) {
           const p = stillRoom.getPlayer(playerId);
           if (p && !p.isConnected) {
             const name = p.name;
+            const engine = getGameEngine(roomCode);
+            if (stillRoom.game && engine) {
+              engine.forfeitPlayer(playerId);
+            }
             stillRoom.removePlayer(playerId);
             emitPlayers(io, stillRoom);
-            system(roomCode, `${name} removed due to inactivity.`);
+            system(roomCode, `${name} was eliminated after disconnecting.`);
             cleanupRoomIfEmpty(roomCode);
           }
         }, DISCONNECT_GRACE_MS); // grace period

--- a/apps/frontend/src/components/GameBoard.tsx
+++ b/apps/frontend/src/components/GameBoard.tsx
@@ -19,6 +19,7 @@ export interface GameState {
     name: string;
     isEliminated: boolean;
     lives: number;
+    isConnected?: boolean;
     bonusProgress?: { remaining: number[]; total: number[] };
   }[];
 }

--- a/apps/frontend/src/components/PlayerBubble.test.tsx
+++ b/apps/frontend/src/components/PlayerBubble.test.tsx
@@ -3,7 +3,13 @@ import { render } from '@testing-library/react';
 import { PlayerBubble } from './PlayerBubble';
 
 describe('PlayerBubble', () => {
-  const basePlayer = { id: 'p1', name: 'Alice', isEliminated: false, lives: 2 };
+  const basePlayer = {
+    id: 'p1',
+    name: 'Alice',
+    isEliminated: false,
+    lives: 2,
+    isConnected: true,
+  } as const;
   it('renders hearts, name, and highlighted text with flash/shake states', () => {
     const { container, rerender } = render(
       <PlayerBubble
@@ -38,5 +44,22 @@ describe('PlayerBubble', () => {
       />,
     );
     expect(container.textContent).toContain('💀');
+  });
+
+  it('shows reconnecting banner when player is disconnected', () => {
+    const { getByText } = render(
+      <PlayerBubble
+        player={{ ...basePlayer, isConnected: false }}
+        isActive={false}
+        isEliminated={false}
+        x={0}
+        y={0}
+        highlighted={null}
+        isUrgent={false}
+        flash={false}
+        shake={false}
+      />,
+    );
+    expect(getByText('Reconnecting…')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/PlayerBubble.tsx
+++ b/apps/frontend/src/components/PlayerBubble.tsx
@@ -48,15 +48,30 @@ function PlayerBubbleComponent({
         />
       )}
       {/* Hearts + Name (independent fixed stack) */}
+      {player.isConnected === false && !isEliminated && (
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[86px]">
+          <span className="rounded-full bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-100/80 shadow-lg">
+            Reconnecting…
+          </span>
+        </div>
+      )}
       <div
-        className="absolute flex flex-col items-center"
+        className={`absolute flex flex-col items-center ${
+          player.isConnected === false && !isEliminated
+            ? 'opacity-50 saturate-0'
+            : ''
+        }`}
         style={{
           left: '50%',
           top: '50%',
           transform: 'translate(-50%, -50%) translateY(-12px)',
         }}
       >
-        <div className="mb-1 flex h-6 w-max items-center justify-center gap-1 sm:h-7">
+        <div
+          className={`mb-1 flex h-6 w-max items-center justify-center gap-1 sm:h-7 ${
+            player.isConnected === false && !isEliminated ? 'grayscale' : ''
+          }`}
+        >
           {isEliminated ? (
             <span className="text-xl leading-none">💀</span>
           ) : (
@@ -104,7 +119,9 @@ function PlayerBubbleComponent({
         <span
           className={`whitespace-nowrap text-lg font-bold uppercase tracking-wide text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.9)] sm:text-xl md:text-2xl ${
             isActive && highlighted ? 'animate-typing' : ''
-          } ${isEliminated ? 'opacity-30' : ''} ${shake ? 'animate-shake text-red-300' : ''}`}
+          } ${isEliminated ? 'opacity-30' : ''} ${
+            player.isConnected === false && !isEliminated ? 'opacity-50' : ''
+          } ${shake ? 'animate-shake text-red-300' : ''}`}
           style={{ visibility: highlighted ? 'visible' : 'hidden' }}
         >
           {highlighted ?? '\u200B'}

--- a/apps/frontend/src/hooks/usePlayerManagement.ts
+++ b/apps/frontend/src/hooks/usePlayerManagement.ts
@@ -14,6 +14,7 @@ export function usePlayerManagement(roomCode: string) {
       id: string;
       name: string;
       isSeated: boolean;
+      isConnected?: boolean;
     }[]
   >([]);
   const [leaderId, setLeaderId] = useState<string | null>(null);
@@ -43,6 +44,7 @@ export function usePlayerManagement(roomCode: string) {
               id: a.id,
               name: a.name,
               isSeated: a.isSeated,
+              isConnected: a.isConnected,
             })),
           );
         }

--- a/apps/frontend/src/socket/eventValidators.ts
+++ b/apps/frontend/src/socket/eventValidators.ts
@@ -30,6 +30,7 @@ interface InternalPlayerShape {
   name: string;
   isEliminated: boolean;
   lives: number;
+  isConnected?: boolean;
 }
 
 const parsePlayersArray = (value: unknown): InternalPlayerShape[] | null => {
@@ -54,6 +55,8 @@ const parsePlayersArray = (value: unknown): InternalPlayerShape[] | null => {
       name,
       isEliminated: Boolean(isEliminated),
       lives,
+      isConnected:
+        typeof raw.isConnected === 'boolean' ? raw.isConnected : undefined,
     });
   }
   return result;

--- a/apps/frontend/src/socket/parsers.test.ts
+++ b/apps/frontend/src/socket/parsers.test.ts
@@ -53,6 +53,7 @@ describe('socket parsers', () => {
       name: 'Alice',
       isEliminated: true,
       lives: 3,
+      isConnected: true,
       bonusProgress: { remaining: [1, 2], total: [5, 6] },
     });
     expect(res!.players[1]).toEqual({
@@ -60,6 +61,7 @@ describe('socket parsers', () => {
       name: 'Unknown',
       isEliminated: false,
       lives: 0,
+      isConnected: true,
     });
   });
   it('parseGameStarted with bonusProgress shape invalid -> omitted', () => {
@@ -81,6 +83,7 @@ describe('socket parsers', () => {
       name: 'Bob',
       isEliminated: false,
       lives: 1,
+      isConnected: true,
       // bonusProgress intentionally omitted
     });
   });
@@ -103,6 +106,7 @@ describe('socket parsers', () => {
       name: 'Unknown',
       isEliminated: false,
       lives: 0,
+      isConnected: true,
     });
   });
   it('parseGameStarted invalid variants', () => {
@@ -176,6 +180,7 @@ describe('socket parsers', () => {
       name: 'Unknown',
       isEliminated: false,
       lives: 0,
+      isConnected: true,
     });
   });
   it('parseTurnStarted invalid variants', () => {
@@ -210,6 +215,7 @@ describe('socket parsers', () => {
       name: 'Unknown',
       isEliminated: false,
       lives: 0,
+      isConnected: true,
     });
   });
   it('parsePlayerTypingUpdate valid', () => {

--- a/apps/frontend/src/socket/parsers.ts
+++ b/apps/frontend/src/socket/parsers.ts
@@ -19,6 +19,7 @@ const DEFAULT_PLAYER = {
   name: 'Unknown',
   isEliminated: false,
   lives: 0,
+  isConnected: true,
 } as const;
 
 export interface PlayerEntryParsed {
@@ -26,6 +27,7 @@ export interface PlayerEntryParsed {
   name: string;
   isEliminated: boolean;
   lives: number;
+  isConnected: boolean;
   bonusProgress?: { remaining: number[]; total: number[] };
 }
 
@@ -34,6 +36,7 @@ const createDefaultPlayerEntry = (): PlayerEntryParsed => ({
   name: DEFAULT_PLAYER.name,
   isEliminated: DEFAULT_PLAYER.isEliminated,
   lives: DEFAULT_PLAYER.lives,
+  isConnected: DEFAULT_PLAYER.isConnected,
 });
 
 const parseBonusProgress = (
@@ -66,6 +69,10 @@ const parsePlayerEntries = (players: unknown[]): PlayerEntryParsed[] =>
       name: typeof obj.name === 'string' ? obj.name : DEFAULT_PLAYER.name,
       isEliminated: !!obj.isEliminated,
       lives: typeof obj.lives === 'number' ? obj.lives : DEFAULT_PLAYER.lives,
+      isConnected:
+        typeof obj.isConnected === 'boolean'
+          ? obj.isConnected
+          : DEFAULT_PLAYER.isConnected,
     };
 
     const bonus = parseBonusProgress(obj.bonusProgress);

--- a/packages/types/src/socket.ts
+++ b/packages/types/src/socket.ts
@@ -182,6 +182,7 @@ export interface GamePlayerView {
   name: string;
   isEliminated: boolean;
   lives: number;
+  isConnected?: boolean;
   // Optional to allow older servers/clients; present during active game payloads
   bonusProgress?: BonusProgressView;
 }


### PR DESCRIPTION
## Summary
- add GameEngine support for forfeiting disconnected players and invoke it once the grace period expires
- surface player connection state in serialized game payloads and frontend parsers
- gray out disconnected player bubbles with a reconnecting banner while they are marked offline

## Testing
- pnpm format
- pnpm lint *(fails: pre-existing lint error in packages/domain/src/chat/ChatMessage.ts)*
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68dab04ce0e4832ea180c4b9a809cd2f