### PR TITLE
Add home navigation button to room page

### DIFF
--- a/apps/frontend/src/pages/RoomPage.test.tsx
+++ b/apps/frontend/src/pages/RoomPage.test.tsx
@@ -115,6 +115,7 @@ vi.mock('react-icons/fa', () => ({
   FaChevronUp: () => null,
   FaChevronDown: () => null,
   FaLink: () => null,
+  FaHome: () => null,
 }));
 
 // useGameState mock (flip via shared var + rerender)
@@ -334,6 +335,25 @@ describe('RoomPage (fast)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('navigates home when clicking the home button', () => {
+    render(
+      <MemoryRouter initialEntries={['/ROOM']}>
+        <Routes>
+          <Route path="/" element={<div>Home view</div>} />
+          <Route
+            path="/:roomCode"
+            element={<RoomPage roomName="Test Room" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const homeButton = screen.getByRole('button', { name: /Go to home/i });
+    fireEvent.click(homeButton);
+
+    expect(screen.getByText('Home view')).toBeInTheDocument();
   });
 
   it('renders players list with leader + seated markers', () => {

--- a/apps/frontend/src/pages/RoomPage.tsx
+++ b/apps/frontend/src/pages/RoomPage.tsx
@@ -6,6 +6,7 @@ import {
   FaChevronUp,
   FaChevronDown,
   FaLink,
+  FaHome,
 } from 'react-icons/fa';
 import Chat from '../components/Chat';
 import { useGameRoom } from '../hooks/useGameRoom';
@@ -169,6 +170,10 @@ export default function RoomPage({ roomName }: { roomName?: string }) {
     [updateRoomRules],
   );
 
+  const handleNavigateHome = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
+
   const formattedElapsed = formatDurationSeconds(elapsedGameTime);
   const localGamePlayer =
     gameState?.players.find((player) => player.id === playerId) ?? null;
@@ -279,6 +284,16 @@ export default function RoomPage({ roomName }: { roomName?: string }) {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleNavigateHome}
+              className="inline-flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-white/80 transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              title="Go to home"
+              aria-label="Go to home"
+            >
+              <FaChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>Home</span>
+            </button>
             <button
               onClick={() => {
                 setInviteCopied(true);
@@ -589,6 +604,16 @@ export default function RoomPage({ roomName }: { roomName?: string }) {
 
         {/* Copy invite link */}
         <div className="flex translate-y-1 items-center gap-3">
+          <button
+            type="button"
+            onClick={handleNavigateHome}
+            className="flex h-9 items-center gap-2 rounded-md border border-white/10 bg-white/5 px-3 text-sm font-medium text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-emerald-400 active:scale-95"
+            aria-label="Go to home"
+            title="Go to home"
+          >
+            <FaHome className="h-4 w-4 text-white/80" aria-hidden="true" />
+            Home
+          </button>
           <button
             onClick={() => {
               setInviteCopied(true);


### PR DESCRIPTION
## Summary
- add a dedicated Home button to the room header on mobile and desktop
- centralize room exit navigation logic and cover it with a regression test

## Testing
- pnpm --filter frontend test -- --run "RoomPage"

------
https://chatgpt.com/codex/tasks/task_e_68f089ef2cc0832e8dcf62158057a473